### PR TITLE
Using the device_name parameter in the Bot class, it is possible to find the devices with different ports by it's unique ADB name

### DIFF
--- a/clashroyalebuildabot/screen.py
+++ b/clashroyalebuildabot/screen.py
@@ -8,9 +8,14 @@ from clashroyalebuildabot.data.constants import SCREENSHOT_WIDTH, SCREENSHOT_HEI
 
 
 class Screen:
-    def __init__(self):
+    def __init__(self, device_name="localhost:5555"):
+        """Sets up the device screen
+
+        Args:
+            device_name (str, optional): The device's name in "adb devices". Defaults to "localhost:5555".
+        """
         self.client = Client(host='127.0.0.1', port=5037)
-        self.device = self.client.device('emulator-5554')
+        self.device = self.client.device(device_name)
 
     def take_screenshot(self):
         """

--- a/example/custom_bot.py
+++ b/example/custom_bot.py
@@ -12,11 +12,11 @@ from clashroyalebuildabot.data.constants import DISPLAY_WIDTH, SCREENSHOT_WIDTH,
 
 
 class CustomBot(Bot):
-    def __init__(self, card_names, debug=False):
+    def __init__(self, card_names, debug=False, device_name="localhost:5555"):
         preset_deck = {'minions', 'archers', 'arrows', 'giant', 'minipekka', 'fireball', 'knight', 'musketeer'}
         if set(card_names) != preset_deck:
             raise ValueError(f'You must use the preset deck with cards {preset_deck} for CustomBot')
-        super().__init__(card_names, CustomAction, debug=debug)
+        super().__init__(card_names, CustomAction, debug=debug, device_name=device_name)
 
     def _preprocess(self):
         """
@@ -36,6 +36,7 @@ class CustomBot(Bot):
                     unit['tile_xy'] = self._get_nearest_tile(*bbox_bottom)
 
     def run(self):
+        print("Custom Bot is now running...")
         while True:
             # Set the state of the game
             self.set_state()

--- a/example/main.py
+++ b/example/main.py
@@ -9,7 +9,7 @@ def main():
     card_names = ['minions', 'archers', 'arrows', 'giant',
                   'minipekka', 'fireball', 'knight', 'musketeer']
     # Define an instance of CustomBot
-    bot = CustomBot(card_names, debug=True)
+    bot = CustomBot(card_names, debug=True, device_name="localhost:5555")
     # and run!
     bot.run()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flatbuffers==2.0
 numpy==1.23.0
-onnxruntime==1.11.1
+onnxruntime==1.12.1
 Pillow==9.1.1
 protobuf==4.21.1
 pure-python-adb==0.3.0.dev0


### PR DESCRIPTION
### Things Added:

- Able to get different bluestacks instance ports by changing the device_name parameter. 
- Added comments for the __init__ in Bot & Screen
- Print message to tell if the CustomBot is running
- Used black formatter to format the files that I worked on
- Set `onnxruntime==1.11.1` to `onnxruntime==1.12.1` because version 1.11.1 couldn't be installed