### PR TITLE
Fast screenshots

### DIFF
--- a/clashroyalebuildabot/screen.py
+++ b/clashroyalebuildabot/screen.py
@@ -1,4 +1,3 @@
-import io
 import subprocess
 
 import numpy as np
@@ -8,18 +7,11 @@ from clashroyalebuildabot.data.constants import SCREENSHOT_WIDTH, SCREENSHOT_HEI
 
 
 class Screen:
-    @staticmethod
-    def take_screenshot():
-        """
-        Take a screenshot of the emulator
-        """
-        screenshot_bytes = subprocess.check_output(['adb', 'exec-out', 'screencap', '-p'])
-        if screenshot_bytes and len(screenshot_bytes) > 5 and screenshot_bytes[5] == 0x0d:
-            screenshot_bytes = screenshot_bytes.replace(b'\r\n', b'\n')
-        screenshot = io.BytesIO(screenshot_bytes)
-        screenshot = Image.open(screenshot).convert('RGB')
-        screenshot = screenshot.resize((SCREENSHOT_WIDTH, SCREENSHOT_HEIGHT), Image.BILINEAR)
-        return screenshot
+    def __init__(self):
+        # Physical size: 720x1280 -> self.width = 720, self.height = 1280
+        window_size = subprocess.check_output(['adb', 'shell', 'wm', 'size'])
+        window_size = window_size.decode('ascii').replace('Physical size: ', '')
+        self.width, self.height = [int(i) for i in window_size.split('x')]
 
     @staticmethod
     def click(x, y):
@@ -27,6 +19,15 @@ class Screen:
         Click at the given (x, y) coordinate
         """
         subprocess.run(['adb', 'shell', 'input', 'tap', str(x), str(y)])
+
+    def take_screenshot(self):
+        """
+        Take a screenshot of the emulator
+        """
+        screenshot_bytes = subprocess.run(['adb', 'exec-out', 'screencap'], check=True, capture_output=True).stdout
+        screenshot = Image.frombuffer('RGBA', (self.width, self.height), screenshot_bytes[12:], 'raw', 'RGBX', 0, 1)
+        screenshot = screenshot.convert('RGB').resize((SCREENSHOT_WIDTH, SCREENSHOT_HEIGHT), Image.BILINEAR)
+        return screenshot
 
 
 def main():


### PR DESCRIPTION
Do not convert the screenshot to PNG with the `-p` flag, but use PIL to decode the raw screenshot bytes instead.

On my machine this reduces the screenshot time from 0.2 seconds to 0.1 seconds.