### PR TITLE
Upgrade pillow version

### DIFF
--- a/clashroyalebuildabot/state/detector.py
+++ b/clashroyalebuildabot/state/detector.py
@@ -32,7 +32,7 @@ class Detector:
         self.side_detector = SideDetector(os.path.join(DATA_DIR, 'side.onnx'))
 
     def _draw_text(self, d, bbox, text):
-        text_width, text_height = self.font.getsize(text)
+        _, _, text_width, text_height = self.font.getbbox(text)
         y_offset = 5
         x = (bbox[0] + bbox[2] - text_width) / 2
         y = bbox[1] - y_offset

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flatbuffers==2.0
 numpy==1.23.0
 onnxruntime==1.12.1
-Pillow==9.1.1
+Pillow==10.1.0
 protobuf==4.21.1
 scipy==1.8.1


### PR DESCRIPTION
`font.get_size()` was deprecated in Pillow 10, so use `font.get_bbox()` instead.