### PR TITLE
Add providers argument to support new ONNX versions

### DIFF
--- a/clashroyalebuildabot/state/onnx_detector.py
+++ b/clashroyalebuildabot/state/onnx_detector.py
@@ -6,7 +6,8 @@ class OnnxDetector:
     def __init__(self, model_path):
         self.model_path = model_path
 
-        self.sess = onnxruntime.InferenceSession(self.model_path)
+        self.sess = onnxruntime.InferenceSession(self.model_path,
+                                                 providers=['CPUExecutionProvider'])
         self.output_name = self.sess.get_outputs()[0].name
         self.input_name = self.sess.get_inputs()[0].name
 


### PR DESCRIPTION
* Add `providers=['CPUExecutionProvider']` to the ONNX session. We are not particularly interested about supporting other providers (the model is fast enough on CPU). If you wanted you could add a GPU execution provider...