### PR TITLE
Automatic ADB Connection Check and Correction

### DIFF
--- a/clashroyalebuildabot/state/error_handler.py
+++ b/clashroyalebuildabot/state/error_handler.py
@@ -1,14 +1,23 @@
 import subprocess
 from loguru import logger
 
+
 def adb_fix():
     try:
         # List all adb devices
-        result = subprocess.run(["adb", "devices"], capture_output=True, text=True)
-        devices = result.stdout.splitlines()[1:-1]  # Skip the first line which is a header
-        
+        result = subprocess.run(
+            ["adb", "devices"], capture_output=True, text=True
+        )
+        devices = result.stdout.splitlines()[
+            1:-1
+        ]  # Skip the first line which is a header
+
         # Filter out empty lines and unauthorized devices
-        devices = [line for line in devices if line.strip() and "unauthorized" not in line]
+        devices = [
+            line
+            for line in devices
+            if line.strip() and "unauthorized" not in line
+        ]
 
         # Log the current connected devices
         logger.info(f"Connected ADB devices: {devices}")
@@ -17,10 +26,14 @@ def adb_fix():
             logger.info("Exactly one ADB device is connected.")
             return
         elif len(devices) > 1:
-            logger.warning("More than one ADB device is connected. Attempting to disconnect 127.0.0.1:5555.")
+            logger.warning(
+                "More than one ADB device is connected. Attempting to disconnect 127.0.0.1:5555."
+            )
             subprocess.run(["adb", "disconnect", "127.0.0.1:5555"])
         else:
-            logger.info("No ADB devices connected. Attempting to connect to 127.0.0.1:5555.")
+            logger.info(
+                "No ADB devices connected. Attempting to connect to 127.0.0.1:5555."
+            )
             subprocess.run(["adb", "connect", "127.0.0.1:5555"])
     except Exception as e:
         logger.error(f"An error occurred in adb_fix: {e}")

--- a/clashroyalebuildabot/state/error_handler.py
+++ b/clashroyalebuildabot/state/error_handler.py
@@ -1,3 +1,5 @@
+# error_handler.py
+
 import subprocess
 from loguru import logger
 
@@ -6,34 +8,36 @@ def adb_fix():
     try:
         # List all adb devices
         result = subprocess.run(
-            ["adb", "devices"], capture_output=True, text=True
+            ["adb", "devices"], capture_output=True, text=True, check=True
         )
-        devices = result.stdout.splitlines()[
-            1:-1
-        ]  # Skip the first line which is a header
+        devices = result.stdout.strip().splitlines()[1:]  # Skip the header
 
-        # Filter out empty lines and unauthorized devices
+        # Filter out unauthorized devices and empty lines
         devices = [
-            line
-            for line in devices
-            if line.strip() and "unauthorized" not in line
+            line.split()[0] for line in devices if "unauthorized" not in line
         ]
 
         # Log the current connected devices
-        logger.info(f"Connected ADB devices: {devices}")
+        logger.debug(f"Connected ADB devices: {devices}")
 
         if len(devices) == 1:
-            logger.info("Exactly one ADB device is connected.")
-            return
+            logger.debug("Exactly one ADB device is connected.")
+            return True
         elif len(devices) > 1:
             logger.warning(
                 "More than one ADB device is connected. Attempting to disconnect 127.0.0.1:5555."
             )
-            subprocess.run(["adb", "disconnect", "127.0.0.1:5555"])
+            subprocess.run(["adb", "disconnect", "127.0.0.1:5555"], check=True)
+            return False
         else:
-            logger.info(
+            logger.debug(
                 "No ADB devices connected. Attempting to connect to 127.0.0.1:5555."
             )
-            subprocess.run(["adb", "connect", "127.0.0.1:5555"])
-    except Exception as e:
+            subprocess.run(["adb", "connect", "127.0.0.1:5555"], check=True)
+            return False
+    except subprocess.CalledProcessError as e:
         logger.error(f"An error occurred in adb_fix: {e}")
+        return False
+    except Exception as e:
+        logger.error(f"An unexpected error occurred in adb_fix: {e}")
+        return False

--- a/clashroyalebuildabot/state/error_handler.py
+++ b/clashroyalebuildabot/state/error_handler.py
@@ -1,0 +1,26 @@
+import subprocess
+from loguru import logger
+
+def adb_fix():
+    try:
+        # List all adb devices
+        result = subprocess.run(["adb", "devices"], capture_output=True, text=True)
+        devices = result.stdout.splitlines()[1:-1]  # Skip the first line which is a header
+        
+        # Filter out empty lines and unauthorized devices
+        devices = [line for line in devices if line.strip() and "unauthorized" not in line]
+
+        # Log the current connected devices
+        logger.info(f"Connected ADB devices: {devices}")
+
+        if len(devices) == 1:
+            logger.info("Exactly one ADB device is connected.")
+            return
+        elif len(devices) > 1:
+            logger.warning("More than one ADB device is connected. Attempting to disconnect 127.0.0.1:5555.")
+            subprocess.run(["adb", "disconnect", "127.0.0.1:5555"])
+        else:
+            logger.info("No ADB devices connected. Attempting to connect to 127.0.0.1:5555.")
+            subprocess.run(["adb", "connect", "127.0.0.1:5555"])
+    except Exception as e:
+        logger.error(f"An error occurred in adb_fix: {e}")

--- a/example/main.py
+++ b/example/main.py
@@ -1,20 +1,29 @@
 """
 A CustomBot implementation through import
 """
-from custom_bot import CustomBot # see custom_bot.py
+
+from custom_bot import CustomBot  # see custom_bot.py
 from clashroyalebuildabot.state.error_handler import adb_fix
 
 
 def main():
     adb_fix()
     # Set required bot variables
-    card_names = ['minions', 'archers', 'arrows', 'giant',
-                  'minipekka', 'fireball', 'knight', 'musketeer']
+    card_names = [
+        "minions",
+        "archers",
+        "arrows",
+        "giant",
+        "minipekka",
+        "fireball",
+        "knight",
+        "musketeer",
+    ]
     # Define an instance of CustomBot
     bot = CustomBot(card_names, debug=False)
     # and run!
     bot.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/example/main.py
+++ b/example/main.py
@@ -1,27 +1,20 @@
 """
 A CustomBot implementation through import
 """
-
-from custom_bot import CustomBot  # see custom_bot.py
+from custom_bot import CustomBot # see custom_bot.py
+from clashroyalebuildabot.state.error_handler import adb_fix
 
 
 def main():
+    adb_fix()
     # Set required bot variables
-    card_names = [
-        "minions",
-        "archers",
-        "arrows",
-        "giant",
-        "minipekka",
-        "fireball",
-        "knight",
-        "musketeer",
-    ]
+    card_names = ['minions', 'archers', 'arrows', 'giant',
+                  'minipekka', 'fireball', 'knight', 'musketeer']
     # Define an instance of CustomBot
-    bot = CustomBot(card_names, debug=True)
+    bot = CustomBot(card_names, debug=False)
     # and run!
     bot.run()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/example/windows_main.py
+++ b/example/windows_main.py
@@ -9,11 +9,13 @@ from rich.text import Text
 from loguru import logger
 from pathlib import Path
 from datetime import datetime
+from clashroyalebuildabot.state.error_handler import adb_fix
 
 ctypes.windll.kernel32.SetConsoleTitleW("Clash Royale Build-A-Bot")
 
 
 def main():
+    adb_fix()
     # Create logs directory if it doesn't exist
     logs_dir = Path("clashroyalebuildabot/logs")
     logs_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This implementation adds an automatic check and correction for ADB connections to ensure that only one ADB device is connected before the Bot starts. If more than one device is connected, it disconnects `127.0.0.1:5555`. If no devices are connected, it connects `127.0.0.1:5555`. Logging is handled using Loguru to provide clear and detailed logs of the actions taken. Additionally, the `error_handler` module is designed to be easily extendable for handling various future errors, making it a robust solution for ongoing error management. This implementation resolves the issue detailed in [GitHub Issue #106](https://github.com/Pbatch/ClashRoyaleBuildABot/issues/106).