### PR TITLE
Add Configurable Logging Level to Bot Configuration

### DIFF
--- a/clashroyalebuildabot/bot/example/custom_bot.py
+++ b/clashroyalebuildabot/bot/example/custom_bot.py
@@ -1,9 +1,11 @@
 import random
 import subprocess
 import time
+import os
+import yaml
+import sys
 
 from loguru import logger
-
 from clashroyalebuildabot.bot import Bot
 from clashroyalebuildabot.bot.bot import Action
 from clashroyalebuildabot.bot.example.custom_action import CustomAction
@@ -23,6 +25,16 @@ class CustomBot(Bot):
     ]
 
     def __init__(self, cards=None, debug=False):
+        config_path = os.path.join(os.path.dirname(__file__), "..", "..", "config.yaml")
+        with open(config_path, encoding="utf-8") as file:
+            config = yaml.safe_load(file)
+
+        log_level = config.get("bot", {}).get("log_level", "INFO").upper()
+
+        logger.remove()
+        logger.add(sys.stdout, level=log_level)
+        logger.add(os.path.join(os.path.dirname(__file__), "..", "bot.log"), rotation="500 MB", level=log_level)
+
         if cards is None:
             cards = self.PRESET_DECK
         if set(cards) != set(self.PRESET_DECK):

--- a/clashroyalebuildabot/config.yaml
+++ b/clashroyalebuildabot/config.yaml
@@ -1,3 +1,9 @@
+bot:
+  # The logging level for the bot.
+  # Use "DEBUG" for detailed debugging information, "INFO" for general information,
+  # "WARNING" for warning messages, "ERROR" for error messages, and "CRITICAL" for critical issues.
+  log_level: "INFO"
+
 adb:
   # The IP address of your device or emulator.
   # Use 127.0.0.1 for a local emulator. If you're connecting to a physical device,

--- a/clashroyalebuildabot/emulator.py
+++ b/clashroyalebuildabot/emulator.py
@@ -1,20 +1,21 @@
 import os
-
 from adb_shell.adb_device import AdbDeviceTcp
 from loguru import logger
 from PIL import Image
 import yaml
-
-from clashroyalebuildabot.constants import SCREENSHOT_HEIGHT
-from clashroyalebuildabot.constants import SCREENSHOT_WIDTH
-from clashroyalebuildabot.constants import SRC_DIR
-
+import sys
+from clashroyalebuildabot.constants import SCREENSHOT_HEIGHT, SCREENSHOT_WIDTH, SRC_DIR
 
 class Emulator:
     def __init__(self):
         config_path = os.path.join(SRC_DIR, "config.yaml")
         with open(config_path, encoding="utf-8") as file:
             config = yaml.safe_load(file)
+
+        log_level = config.get("bot", {}).get("log_level", "INFO").upper()
+        logger.remove()
+        logger.add(sys.stdout, level=log_level)
+        logger.add(os.path.join(SRC_DIR, "bot.log"), rotation="500 MB", level=log_level)
 
         adb_config = config["adb"]
         device_ip = adb_config["ip"]

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import os
 import sys
 import threading
 import time
+import yaml
 from loguru import logger
 from clashroyalebuildabot.bot.example.custom_bot import CustomBot
 from clashroyalebuildabot.constants import DEBUG_DIR
@@ -25,8 +26,18 @@ def main():
     bot.run()
 
 if __name__ == "__main__":
+    config_path = os.path.join(os.path.dirname(__file__), "clashroyalebuildabot/config.yaml")
+    with open(config_path, encoding="utf-8") as file:
+        config = yaml.safe_load(file)
+
+    log_level = config.get("bot", {}).get("log_level", "INFO").upper()
+
+    logger.remove()
+    logger.add(sys.stdout, level=log_level)
+    logger.add(os.path.join(DEBUG_DIR, "bot.log"), rotation="500 MB", level=log_level)
+
+    # Update-Prüfung und Hauptprogramm starten
     Updater().check_for_update()
-    logger.add(os.path.join(DEBUG_DIR, "bot.log"), rotation="500 MB")
     title_thread = threading.Thread(target=update_terminal_title, daemon=True)
     title_thread.start()
     main()


### PR DESCRIPTION
### Description

This pull request introduces a new configuration section `bot:` in the `config.yaml` file, allowing users to set the logging level for the bot. The `log_level` parameter can be configured to control the verbosity of log messages, with options such as "DEBUG", "INFO", "WARNING", "ERROR", and "CRITICAL". The logging configuration has been implemented across `main.py`, `custom_bot.py`, and `emulator.py` to ensure consistent logging behavior throughout the application.

### Changes

- Added `bot:` section with `log_level` parameter in `config.yaml`
- Updated `main.py` to read and apply the `log_level` configuration
- Modified `custom_bot.py` and `emulator.py` to use the configured logging level
- Included appropriate import statements for `sys` in relevant files