### PR TITLE
Add "crbab-venv" to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 clashroyalebuildabot/debug
 clashroyalebuildabot/emulator/platform-tools
 env/
+crbab-venv/


### PR DESCRIPTION
In the wiki, it says to create a virtual environment named "crbab-venv"