### PR TITLE
Fix defense placement when the threat is on the right

### DIFF
--- a/clashroyalebuildabot/actions/generic/defense_action.py
+++ b/clashroyalebuildabot/actions/generic/defense_action.py
@@ -28,4 +28,7 @@ class DefenseAction(Action):
         if lhs >= rhs and self.tile_x == 9:
             return [0]
 
+        if rhs > lhs and self.tile_x == 8:
+            return [0]
+
         return [1]


### PR DESCRIPTION
`DefenseAction` only guards one side. It returns `[0]` for the right placement `(9, 9)` when there are at least as many enemies on the left, but there's no matching check for the left placement `(8, 9)` when the enemies are on the right. So if the enemy pushes on the right, both `(8, 9)` and `(9, 9)` score `[1]` and the bot can end up defending on the wrong side.

Quick repro with all enemies on the right half:

```
before:  play LEFT (8,9) -> [1]   play RIGHT (9,9) -> [1]
after:   play LEFT (8,9) -> [0]   play RIGHT (9,9) -> [1]
```

Added the mirror condition so the left placement is skipped when the right side has more enemies. Left-side threats already worked and are unchanged.